### PR TITLE
Ignore git directory in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,10 @@
 # See https://docs.docker.com/engine/reference/builder/#dockerignore-file
 # Put files here that you don't want copied into your bundle's invocation image
-.gitignore
 Dockerfile.tmpl
+
+# Ignore git directories
+.git
+.gitignore
 
 vitess/**
 


### PR DESCRIPTION
This will prevent docker images getting slower to build as the git history grows