### PR TITLE
Edits to notes.md and fixes in openfaas-values.yaml and tekton-el-ingress.yaml

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -301,7 +301,7 @@ Browse to http://localhost:8060
 Deploy Linkered
 ```
 # Install cli
-curl -sL https://run.linkerd.io/install | sed s/LINKERD2_VERSION=.*/LINKERD2_VERSION=${LINKERD2_VERSION:-stable-2.10.0}/ | sh
+curl -sL https://run.linkerd.io/install | sed s/LINKERD2_VERSION=.\*/LINKERD2_VERSION=${LINKERD2_VERSION:-stable-2.10.0}/ | sh
 export PATH=$PATH:$HOME/.linkerd2/bin
 linkerd version
 linkerd check --pre

--- a/notes.md
+++ b/notes.md
@@ -308,7 +308,7 @@ linkerd check --pre
 
 # Generate certificates.
 wget https://github.com/smallstep/cli/releases/download/v0.15.2/step-cli_0.15.2_amd64.deb
-​sudo dpkg -i step-cli_0.15.2_amd64.deb
+sudo dpkg -i step-cli_0.15.2_amd64.deb
 
 step certificate create identity.linkerd.cluster.local ca.crt ca.key --profile root-ca --no-password --insecure
 step certificate create identity.linkerd.cluster.local issuer.crt issuer.key --ca ca.crt --ca-key ca.key --profile intermediate-ca --not-after 8760h --no-password --insecure
@@ -400,9 +400,7 @@ kubectl apply -f yml/tekton-limit-range.yaml
 kubectl apply -f yml/app-admin-role.yaml -n conexp-mvp-devops
 ```
 
-Update Secret (basic-user-pass) for registry credentails, TriggerBinding for registry name,namespaces in triggers.yaml
-Create a SendGrid Account and set an API key for use. Reference this [Link](https://sendgrid.com/) to Create a Free Send Grid Account
-and thus a SendGrid Key
+Update secret (basic-user-pass) for registry credentails, TriggerBinding for registry name, and namespaces in triggers.yaml. Create a SendGrid Account and set an API key for use. Reference this [link](https://sendgrid.com/) to create a free SendGrid account and get the SendGrid API key.
 ```
 sendGridApiKey=<<set the api key>>
 appHostName=$topLevelDomain

--- a/notes.md
+++ b/notes.md
@@ -441,4 +441,4 @@ Make a change to the readme.md file and observe the deployment in tekton dashboa
 ```
 ## Launch the Application
 Navigate to the FQDN of the NGINX ingress controller set up in the first step, also refered to as the *topLevelDomain* in the first step. For example **uniquename.centralus.cloudapp.azure.com**.
-This will launch the application and you can proceed to create, update, delete expenses.
+This will launch the application and you can proceed to create, update, delete expenses. 

--- a/notes.md
+++ b/notes.md
@@ -430,9 +430,9 @@ kubectl apply -f yml/tekton-el-ingress.yaml -n conexp-mvp-devops
 
 # Payload URL to be used for creating the webhook
 echo https://$cicdWebhookHost/cd
+```
 
-Create a webhook in the git repo of the source code by navigating to {Repo} -> Setting -> Webhook -> Add Webhook
-Enter the Payload URL from above, select the Content type as application/json and leavet he rest as defaults
+Create a Webook in the GitHub repo of the source code by navigating to {Repo} -> Setting -> Webhook -> Add Webhook. Enter the Payload URL from above, select the Content type as **application/json** and leave the rest as defaults
 
 Make a change to the readme.md file and observe the deployment in tekton dashboard
 

--- a/notes.md
+++ b/notes.md
@@ -205,7 +205,7 @@ Create the databases
 ```bash
 kubectl run -n mysql -i -t ubuntu --image=ubuntu:18.04 --restart=Never -- bash -il
 apt-get update && apt-get install mysql-client -y
-mysql -h mysql -p
+mysql -h mysql --password=FTA@CNCF0n@zure3
 show databases;
 
 CREATE DATABASE conexpweb;

--- a/notes.md
+++ b/notes.md
@@ -432,11 +432,12 @@ kubectl apply -f yml/tekton-el-ingress.yaml -n conexp-mvp-devops
 echo https://$cicdWebhookHost/cd
 ```
 
-Create a Webook in the GitHub repo of the source code by navigating to {Repo} -> Setting -> Webhook -> Add Webhook. Enter the Payload URL from above, select the Content type as **application/json** and leave the rest as defaults
+Create a Webook in the GitHub repo of the source code by navigating to {Repo} -> Setting -> Webhook -> Add Webhook. Enter the Payload URL from above, select the Content type as **application/json** and leave the rest as defaults.
 
-Make a change to the readme.md file and observe the deployment in tekton dashboard
+Make a change to the readme.md file and observe the deployment in Tekton dashboard.
 
-```
 ## Launch the Application
+
 Navigate to the FQDN of the NGINX ingress controller set up in the first step, also refered to as the *topLevelDomain* in the first step. For example **uniquename.centralus.cloudapp.azure.com**.
+
 This will launch the application and you can proceed to create, update, delete expenses. 

--- a/notes.md
+++ b/notes.md
@@ -347,7 +347,7 @@ kubectl annotate namespace openfaas config.linkerd.io/trace-collector=collector.
 kubectl annotate namespace ingress-basic config.linkerd.io/trace-collector=collector.linkerd-jaeger:55678
 ```
 
-Open the dashboard in browser
+Open the dashboard in browser (linkerd-viz may take up to ~12 minutes to start)
 ```
 linkerd viz dashboard
 ```

--- a/notes.md
+++ b/notes.md
@@ -1,6 +1,6 @@
 # Setup
 
-Create a Kubernetes Cluster
+Create a Kubernetes cluster with a minimum of 3 nodes and ~8+GB per node (e.g., Standard_DS3_v2)
 
 Fork this repository (needed to enable CD) and clone it
 

--- a/notes.md
+++ b/notes.md
@@ -59,7 +59,7 @@ helm install harbor-nginx-ingress ingress-nginx/ingress-nginx \
     --set controller.nodeSelector."beta\.kubernetes\.io/os"=linux \
     --set defaultBackend.nodeSelector."beta\.kubernetes\.io/os"=linux
 
-# Label the ingress-basic namespace to disable cert resource validation
+# Label the harbor-ingress-system namespace to disable cert resource validation
 kubectl label namespace harbor-ingress-system cert-manager.io/disable-validation=true
 ```
 

--- a/yml/openfaas-values.yaml
+++ b/yml/openfaas-values.yaml
@@ -151,6 +151,10 @@ nats:
 # ingress configuration
 ingress:
   enabled: true
+  ## https://github.com/openfaas/faas-netes/blob/bf6164bebe0d350f18b42f26596dd48862cb3772/chart/openfaas/values.yaml#L179
+  ## For k8s >= 1.18 you need to specify the pathType
+  ## See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#better-path-matching-with-path-types
+  pathType: ImplementationSpecific
   # Used to create Ingress record (should be used with exposeServices: false).
   hosts:
     - host: gateway.openfaas.local  # Replace with gateway.example.com if public-facing

--- a/yml/tekton-el-ingress.yaml
+++ b/yml/tekton-el-ingress.yaml
@@ -1,17 +1,26 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-resource
   annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    acme.cert-manager.io/http01-ingress-class: nginx
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/rewrite-target: /$1  
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /cd/$2
 spec:
-  rules:
+ tls:
+ - hosts: 
+   - {cicdWebhook}
+   secretName: webhook-tls
+ rules:
   - host: {cicdWebhook}
     http:
       paths:
-      - path: /cd
+      - path: /cd(/|$)(.*)
+        pathType: Prefix
         backend:
-          serviceName: el-conexp-listener
-          servicePort: 8080
+          service:
+            name: el-conexp-listener
+            port: 
+              number: 8080


### PR DESCRIPTION
> When merging, please use squash merge to combine all of the commits.

* Specify that Kubernetes cluster must be at least 3 nodes with over 8GB per node. When using 3 nodes of DS2_v2, I saw that rook wasn't able to start properly sometimes. It worked OK with 3 of DS3_v2.
* Other small edits in the nodes.md (e.g., fix sed replacement on zsh, remove invalid character from sudo, specify ~12 min install for linkerd-viz, etc.)
* Fix openfaas-values.yaml by including pathType in the ingress config (required on k8s >= 1.18)
* Improve tekton-el-ingress.yaml (i.e., tekton webhook at /cd) to make it work with HTTPS, move to apiVersion=networking.k8s.io/v1, and change ingress definition for /cd endpoint so that it continues to work even after the conexp app is deployed with its own ingress on the same host